### PR TITLE
fix: detectBrowserLanguage overrides non-root paths

### DIFF
--- a/src/plugins/main.js
+++ b/src/plugins/main.js
@@ -245,7 +245,7 @@ export default async (context) => {
 
       if (browserLocale) {
         // Handle cookie option to prevent multiple redirections
-        if (alwaysRedirect || (route.path == '/' && (!useCookie || !getLocaleCookie()))) {
+        if (alwaysRedirect || (route.path === '/' && (!useCookie || !getLocaleCookie()))) {
           let redirectToLocale = fallbackLocale
 
           // Use browserLocale if we support it, otherwise use fallbackLocale

--- a/src/plugins/main.js
+++ b/src/plugins/main.js
@@ -245,7 +245,7 @@ export default async (context) => {
 
       if (browserLocale) {
         // Handle cookie option to prevent multiple redirections
-        if (!useCookie || alwaysRedirect || !getLocaleCookie()) {
+        if (alwaysRedirect || (route.path == '/' && (!useCookie || !getLocaleCookie()))) {
           let redirectToLocale = fallbackLocale
 
           // Use browserLocale if we support it, otherwise use fallbackLocale


### PR DESCRIPTION
This commit tries to fix issue #455.

With the fix:

- if the user visits the root without prefixes AND does not have a cookie already, it honors the detectBrowserLanguage settings, redirecting to the detected language
- if the user visits a prefixed non-root page, then the url prefix is honored instead of the browsers language or a saved cookie.

Solution provided by @konr4d. I'm just doing the PR to speed up the process :)